### PR TITLE
Ajout E85 et Gplc + maj documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 # prixCarburant-home-assistant
 Client python permettant d'interroger l'openData du gouvernement sur le prix du carburant.
+https://www.prix-carburants.gouv.fr/ 
 Le client permet de :
- - Trouver les stations les plus proches dans un cercle de X km configurable
+ - Trouver les stations les plus proches dans un cercle de X km configurable a partif de votre adresse defini dans home assistant
  - Extraire des stations spécifiques via son ID
- 
- 
+
+
+
 Exemple de configuration:
 
 ### Configuration pour récupérer les stations dans un rayon de 20 km
@@ -26,5 +28,48 @@ sensor:
 ```
 
 
+Exemple de données extraites :
+```
+Station ID: '44300020'
+Gasoil: '1.519'
+Last Update Gasoil: '2021-02-23T19:23:06'
+E95: '1.622'
+Last Update E95: '2021-02-23T19:23:07'
+E98: '1.685'
+Last Update E98: '2021-02-23T19:23:08'
+E10: '1.563'
+Last Update E10: '2021-02-23T19:23:07'
+E85: None
+Last Update E85: ''
+GPLc: '0.909'
+Last Update GPLc: '2021-02-23T19:23:07'
+Station Address: 162 Route de Rennes Nantes
+Station name: undefined
+Last update: '2021-02-24'
+unit_of_measurement: €
+friendly_name: PrixCarburant_44300020
+icon: 'mdi:currency-eur'
+```
+
+Exemple de carte markdown
+
+```
+{{state_attr("sensor.prixcarburant_44300020", "Station name")}} - Maj : {{state_attr("sensor.prixcarburant_44300020", "Last update")}}
+{%- if state_attr("sensor.prixcarburant_44300020", "Gasoil") != "None"  %}
+Gasoil : {{ state_attr("sensor.prixcarburant_44300020", "Gasoil") }} €
+{%- endif %}
+{%- if state_attr("sensor.prixcarburant_44300020", "E10") != "None"  %}
+E10 : {{ state_attr("sensor.prixcarburant_44300020", "E10") }} €
+{%- endif %}
+{%- if state_attr("sensor.prixcarburant_44300020", "E95") != "None"  %}
+SP95 : {{ state_attr("sensor.prixcarburant_44300020", "E95") }} €
+{%- endif %}
+{%- if   state_attr("sensor.prixcarburant_44300020", "E98") != "None"  %}
+SP98 : {{ state_attr("sensor.prixcarburant_44300020", "E98") }} €
+{%- endif %}
+{%- if   state_attr("sensor.prixcarburant_44300020", "GPLc") != "None"  %}
+GPLc : {{ state_attr("sensor.prixcarburant_44300020", "GPLc") }} €
+{%- endif %}
+```
 
 Source code du client si vous souhaitez contribuer : "https://github.com/ryann72/essence"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 # prixCarburant-home-assistant
 Client python permettant d'interroger l'openData du gouvernement sur le prix du carburant.
+
 https://www.prix-carburants.gouv.fr/ 
+
 Le client permet de :
- - Trouver les stations les plus proches dans un cercle de X km configurable a partif de votre adresse defini dans home assistant
+ - Trouver les stations les plus proches dans un cercle de X km configurable a partir de votre adresse defini dans home assistant
  - Extraire des stations spécifiques via son ID
 
 
-Aide à l'installation depuis HACS:
+Aide à l'installation depuis HACS :
 
 Dans HACS, cliquer sur ... puis depots personnalisés 
+
 Ajouter :
-URL : https://github.com/ryann72/prixCarburant-home-assistant
-Catégorie : Intégration
+
+-URL : https://github.com/ryann72/prixCarburant-home-assistant
+-Catégorie : Intégration
 
 
 Exemple de configuration :
@@ -59,7 +63,9 @@ icon: 'mdi:currency-eur'
 ```
 
 Exemple de carte markdown :
+
 Permet d'afficher le prix des différents carburants proposés par la station.
+
 La date d'actualisation des prix est également affichée
 ```
 {{state_attr("sensor.prixcarburant_44300020", "Station name")}} - Maj : {{state_attr("sensor.prixcarburant_44300020", "Last update")}}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,15 @@ Le client permet de :
  - Extraire des stations spécifiques via son ID
 
 
+Aide à l'installation depuis HACS:
 
-Exemple de configuration:
+Dans HACS, cliquer sur ... puis depots personnalisés 
+Ajouter :
+URL : https://github.com/ryann72/prixCarburant-home-assistant
+Catégorie : Intégration
+
+
+Exemple de configuration :
 
 ### Configuration pour récupérer les stations dans un rayon de 20 km
 ```
@@ -51,8 +58,9 @@ friendly_name: PrixCarburant_44300020
 icon: 'mdi:currency-eur'
 ```
 
-Exemple de carte markdown
-
+Exemple de carte markdown :
+Permet d'afficher le prix des différents carburants proposés par la station.
+La date d'actualisation des prix est également affichée
 ```
 {{state_attr("sensor.prixcarburant_44300020", "Station name")}} - Maj : {{state_attr("sensor.prixcarburant_44300020", "Last update")}}
 {%- if state_attr("sensor.prixcarburant_44300020", "Gasoil") != "None"  %}
@@ -73,3 +81,6 @@ GPLc : {{ state_attr("sensor.prixcarburant_44300020", "GPLc") }} €
 ```
 
 Source code du client si vous souhaitez contribuer : "https://github.com/ryann72/essence"
+
+
+Il s'agit d'un fork de https://github.com/max5962/prixCarburant-home-assistant, mis à jour afin de recuperer le E85 et le GPLc

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Dans HACS, cliquer sur ... puis depots personnalisés
 
 Ajouter :
 
--URL : https://github.com/ryann72/prixCarburant-home-assistant
--Catégorie : Intégration
+- URL : https://github.com/ryann72/prixCarburant-home-assistant
+- Catégorie : Intégration
 
 
 Exemple de configuration :

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ sensor:
 
 
 
-Source code du client si vous souhaitez contribuer : "https://github.com/max5962/essence"
+Source code du client si vous souhaitez contribuer : "https://github.com/ryann72/essence"

--- a/custom_components/prixCarburant/__init__.py
+++ b/custom_components/prixCarburant/__init__.py
@@ -1,1 +1,1 @@
-REQUIREMENTS  = ['Prix-Carburant-FR-Client==1.0.1']
+REQUIREMENTS  = ['Prix-Carburant-FR-Client==1.0.2']

--- a/custom_components/prixCarburant/__init__.py
+++ b/custom_components/prixCarburant/__init__.py
@@ -1,1 +1,1 @@
-REQUIREMENTS  = ['PrixCarburantClient==1.0.6']
+REQUIREMENTS  = ['Prix-Carburant-FR-Client==1.0.0']

--- a/custom_components/prixCarburant/__init__.py
+++ b/custom_components/prixCarburant/__init__.py
@@ -1,1 +1,1 @@
-REQUIREMENTS  = ['Prix-Carburant-FR-Client==1.0.0']
+REQUIREMENTS  = ['Prix-Carburant-FR-Client==1.0.1']

--- a/custom_components/prixCarburant/__init__.py
+++ b/custom_components/prixCarburant/__init__.py
@@ -1,1 +1,1 @@
-REQUIREMENTS  = ['PrixCarburantClient==1.0.5']
+REQUIREMENTS  = ['PrixCarburantClient==1.0.6']

--- a/custom_components/prixCarburant/manifest.json
+++ b/custom_components/prixCarburant/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/ryann72/prixCarburant-home-assistant/blob/master/README.md",
   "dependencies": [],
   "codeowners": [],
-  "requirements": ["Prix-Carburant-FR-Client==1.0.1"]
+  "requirements": ["Prix-Carburant-FR-Client==1.0.2"]
 }

--- a/custom_components/prixCarburant/manifest.json
+++ b/custom_components/prixCarburant/manifest.json
@@ -2,8 +2,8 @@
 {
   "domain": "prixCarburant",
   "name": "prixCarburant",
-  "documentation": "https://github.com/max5962/prixCarburant-home-assistant/blob/master/README.md",
+  "documentation": "https://github.com/ryann72/prixCarburant-home-assistant/blob/master/README.md",
   "dependencies": [],
   "codeowners": [],
-  "requirements": ["PrixCarburantClient==1.0.5"]
+  "requirements": ["PrixCarburantClient==1.0.6"]
 }

--- a/custom_components/prixCarburant/manifest.json
+++ b/custom_components/prixCarburant/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/ryann72/prixCarburant-home-assistant/blob/master/README.md",
   "dependencies": [],
   "codeowners": [],
-  "requirements": ["PrixCarburantClient==1.0.6"]
+  "requirements": ["Prix-Carburant-FR-Client==1.0.0"]
 }

--- a/custom_components/prixCarburant/manifest.json
+++ b/custom_components/prixCarburant/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/ryann72/prixCarburant-home-assistant/blob/master/README.md",
   "dependencies": [],
   "codeowners": [],
-  "requirements": ["Prix-Carburant-FR-Client==1.0.0"]
+  "requirements": ["Prix-Carburant-FR-Client==1.0.1"]
 }

--- a/custom_components/prixCarburant/sensor.py
+++ b/custom_components/prixCarburant/sensor.py
@@ -13,10 +13,14 @@ ATTR_GASOIL = 'Gasoil'
 ATTR_E95 = 'E95'
 ATTR_E98 = 'E98'
 ATTR_E10 = 'E10'
+ATTR_GPL = 'GPLc'
+ATTR_E85 = 'E85'
 ATTR_GASOIL_LAST_UPDATE = 'Last Update Gasoil'
 ATTR_E95_LAST_UPDATE= 'Last Update E95'
 ATTR_E98_LAST_UPDATE = 'Last Update E98'
 ATTR_E10_LAST_UPDATE = 'Last Update E10'
+ATTR_GPL_LAST_UPDATE = 'Last Update GPLc'
+ATTR_E85_LAST_UPDATE = 'Last Update E85'
 ATTR_ADDRESS = "Station Address"
 ATTR_NAME = "Station name"
 ATTR_LAST_UPDATE = "Last update"
@@ -39,7 +43,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     from prixCarburantClient.prixCarburantClient import PrixCarburantClient
-    #from .old import PrixCarburantClient
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
     logging.info("[prixCarburantLoad] start")
     """Setup the sensor platform."""
@@ -129,6 +132,10 @@ class PrixCarburant(Entity):
             ATTR_E98_LAST_UPDATE: self.station.e98['maj'],
             ATTR_E10: self.station.e10['valeur'],
             ATTR_E10_LAST_UPDATE: self.station.e10['maj'],
+            ATTR_E85: self.station.e85['valeur'],
+            ATTR_E85_LAST_UPDATE: self.station.e85['maj'],
+            ATTR_GPL: self.station.gpl['valeur'],
+            ATTR_GPL_LAST_UPDATE: self.station.gpl['maj'],
             ATTR_ADDRESS: self.station.adress,
             ATTR_NAME: self.station.name,
             ATTR_LAST_UPDATE: self.client.lastUpdate.strftime('%Y-%m-%d')

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,7 @@
   "name": "prixCarburant",
   "country": "FR",
   "domains": ["sensor"],
+  "render_readme": true,
+  "documentation": "https://github.com/ryann72/prixCarburant-home-assistant",
   "homeassistant": "0.99.0"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Addon repository of prixCarburant",
-  "url": "https://github.com/max5962/prixCarburant-home-assistant/",
-  "maintainer": "Maxime Wantiez"
+  "url": "https://github.com/ryann72/prixCarburant-home-assistant",
+  "maintainer": "Yann RITTER"
 }


### PR DESCRIPTION
Bonjour, 

J'ai réalisé la modification afin de remonter l'E85 et le GPLc en plus dans la liste des carburants.
J'ai modifié afin de faire également remonter la doc sous hacs et j'ai complété la doc.
Je fais également une pull request pour l'essence (client).

Merci pour ton travail initial